### PR TITLE
Support OSX <= 16

### DIFF
--- a/libcbm/resources/__init__.py
+++ b/libcbm/resources/__init__.py
@@ -123,8 +123,7 @@ def get_libcbm_bin_path():
         minor = version_tokens[1]
         matched_ver = (
             (int(major) == 10 and int(minor) >= 12)
-            or (int(major) == 11)
-            or (int(major) == 12)
+            or (int(major) >= 11 int(major) <= 16)
         )
         # Get the full path to the dylib #
         dylib = os.path.join(


### PR DESCRIPTION
Running test script run_1_1_simulate.ipynb shows the existing osx build works on Sonoma OSX16, so taking away the check that prevents OS versions <= 12 from using libcbm.